### PR TITLE
Added M-up and M-down as navigation keys for previous/next command

### DIFF
--- a/inf-mongo.el
+++ b/inf-mongo.el
@@ -229,7 +229,9 @@ Most of this is borrowed from python.el"
 ;;;###autoload
 (defvar inf-mongo-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "\C-x\C-e" 'mongo-send-last-sexp)
+    (define-key map (kbd "C-x C-e")  'mongo-send-last-sexp)
+    (define-key map (kbd "<M-up>")   'comint-previous-input)
+    (define-key map (kbd "<M-down>") 'comint-next-input)
     map))
 
 ;;;###autoload


### PR DESCRIPTION
Added key bindings for underlying comint mode to support scrolling through the command history using M-up and M-down. Preserves the existing functionality of the up/down keys.